### PR TITLE
fix: pedidos loja fisica da rota /order/:store passam a alimentar ord…

### DIFF
--- a/src/controllers/createOrderController.js
+++ b/src/controllers/createOrderController.js
@@ -1,16 +1,21 @@
 import { insertOrder } from "../services/orderServicesNuvem.js"
+import { processOrderFromNuvemshop } from "../services/segmentacaoServices.js"
 
 export const createOrder = async (req, res) => {
 	const { store } = req.params
 	const order = req.body
 
-	if (!order || !store) {
+	if (!order || !order[0] || !store) {
 		return res.status(400).json({ error: "Store and order are required" })
 	}
 
 	try {
 		console.log("Cadastrando pedido", order[0])
-		await insertOrder(order[0], store) // Chama a função para inserir os pedidos no banco de dados
+		// 1) Tabela legada (pedidos_<loja>): mantém compatibilidade com o dump/migração.
+		await insertOrder(order[0], store)
+		// 2) orders_shop + clients/products/coupons/daily_sales: mesmo pipeline dos webhooks
+		//    Nuvemshop, que já trata loja física. É daqui que o app (Pedidos/Dashboard) lê.
+		await processOrderFromNuvemshop(order[0].data)
 
 		return res.status(201).json({ message: "Pedido cadastrado!" })
 	} catch (error) {

--- a/src/db/dataBaseQueryList.js
+++ b/src/db/dataBaseQueryList.js
@@ -33,6 +33,18 @@ export const dataBase = {
 	product: "categorias"
 }
 
+// order_id sintético p/ pedidos de loja física em orders_shop (PK global). Esses pedidos não
+// têm `number`/`id` da Nuvemshop — só `token`. Usamos `token + offset por loja`, acima do range
+// histórico (numericUuid ~1e6–1e7 e migração até 2e12) e bem abaixo de 2^53 (seguro no front).
+// Determinístico → reenvio do mesmo token faz UPDATE via ON CONFLICT(order_id) em vez de duplicar.
+export const LOJA_FISICA_ORDER_ID_OFFSET = {
+	1146504: 3_000_000_000_000, // artepropria
+	3889735: 4_000_000_000_000 // outlet
+}
+
+// token placeholder usado no dump legado por 1.5k pedidos distintos: NÃO é chave única.
+export const TOKEN_PLACEHOLDER = "999999"
+
 export const dataBaseDb = {
 	ads: {
 		transform: (delivery) => ({
@@ -197,7 +209,23 @@ export function mapNuvemshopToDelivery(nuvemData) {
 	logWebhookDB("Iniciando mapNuvemshopToDelivery")
 	// Usa sempre o identificador real do pedido. Antes, pedidos "Loja Fisica"
 	// recebiam order_id = "Loja Fisica" (literal) e colidiam entre si em orders_shop.
-	const orderNumber = nuvemData?.number || nuvemData?.order_id || nuvemData?.id
+	// Pedido de loja física? (storefront "Loja" ou "Loja Fisica")
+	const isLojaFisica =
+    nuvemData?.storefront === "Loja" || nuvemData?.storefront === "Loja Fisica"
+	// Pedidos de loja física não têm `number`/`id` da Nuvemshop (só `token`). Deriva o order_id
+	// determinístico a partir do token real (guard contra o placeholder) + offset da loja.
+	const storeIdNum = Number(nuvemData?.store_id)
+	const tokenReal =
+    nuvemData?.token && String(nuvemData.token) !== TOKEN_PLACEHOLDER
+    	? Number(nuvemData.token)
+    	: null
+	const orderNumber =
+    nuvemData?.number ||
+    nuvemData?.order_id ||
+    nuvemData?.id ||
+    (isLojaFisica && tokenReal
+    	? tokenReal + (LOJA_FISICA_ORDER_ID_OFFSET[storeIdNum] || 0)
+    	: undefined)
 	logWebhookDB("orderNumber:", orderNumber)
 	const now = new Date().toISOString()
 
@@ -214,10 +242,6 @@ export function mapNuvemshopToDelivery(nuvemData) {
 		GABRIEL: "45688888888",
 		CHATBOT: "45699999999"
 	}
-
-	// Pedido de loja física? (storefront "Loja" ou "Loja Fisica")
-	const isLojaFisica =
-    nuvemData?.storefront === "Loja" || nuvemData?.storefront === "Loja Fisica"
 
 	// Filial: billing_business_name; fallback CHATBOT (mesma regra do ChartLojas do front).
 	let lojaFisica = null

--- a/src/services/orderServicesNuvem.js
+++ b/src/services/orderServicesNuvem.js
@@ -695,6 +695,16 @@ export const insertOrder = async (order, store) => {
 	try {
 		const numericUuid = generateNumericId()
 
+		// order_id estável: o wrapper recebido ({ data }) não tem `.orderId`, então antes gravava
+		// sempre NULL e o ON CONFLICT(order_id) nunca deduplicava (reenvio criava duplicata).
+		// Loja física usa o `token` como chave (guard contra o placeholder "999999", que se repete
+		// em pedidos distintos); sem token real, cai no numericUuid (único, não colapsa).
+		const tokenReal =
+			order.data.token && String(order.data.token) !== "999999"
+				? Number(order.data.token)
+				: null
+		const orderIdEstavel = tokenReal ?? numericUuid
+
 		// Concatena o owner_note com o UUID
 		const finalOwnerNote = `${order.data.owner_note}_${numericUuid}`
 
@@ -718,7 +728,7 @@ export const insertOrder = async (order, store) => {
 			order.data.free_shipping_config || null,
 			JSON.stringify(order.data.fulfillments) || null,
 			order.data.has_shippable_products || null,
-			order.orderId || null,
+			orderIdEstavel,
 			numericUuid,
 			order.data.paid_at || null,
 			order.data.payment_count || null,


### PR DESCRIPTION
…ers_shop

- createOrder agora faz dual-write: legado + processOrderFromNuvemshop (orders_shop
  + clients/products/coupons/daily_sales), fluxo que o app realmente le.
- mapNuvemshopToDelivery deriva order_id de loja fisica via token + offset por loja (artepropria 3e12, outlet 4e12); deterministico e idempotente.
- insertOrder deduplica no legado usando o token como chave (guard contra o placeholder 999999); antes gravava order_id NULL e reenvio duplicava.